### PR TITLE
Allow for stacks to be reused by specifying the name only.

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,10 +4,10 @@ This small cli tools generates rokka stacks and uploads them to rokka.io.
 
 ## Installation
 Run the following command in your project folder:
+
 ```
 npm install rokka-stacks-generator
 ```
-Then install it with: `npm install @ayalon/rokka-stacks-generator'
 
 ## How to use it
 Add a stacks.yml file to your component folder. The command will recursively 
@@ -19,7 +19,7 @@ npx rokka-stacks-generator --folder /your/folder --output /output/rokka.json --a
 
 ### Example
 
-```
+```yml
 name: slider_image
 ratio:
   w: 4
@@ -37,7 +37,18 @@ pictures:
   widescreen:
     width: 800
     height: 600
-
 ```
 
 Now you can run the cli command and search for the stacks.yml definitions. Provide a folder to look for.
+
+### Noop example
+
+In case you need a `noop` stack, you can generate one by defining `noop` as the value of the `pictures` viewport value.
+
+Example:
+
+```yml
+name: noop_test
+pictures:
+  sm: noop
+```

--- a/README.md
+++ b/README.md
@@ -41,14 +41,14 @@ pictures:
 
 Now you can run the cli command and search for the stacks.yml definitions. Provide a folder to look for.
 
-### Noop example
+### Reuse example
 
-In case you need a `noop` stack, you can generate one by defining `noop` as the value of the `pictures` viewport value.
+In case you need to reuse a stack, you can generate one by defining the name as the value of the `pictures` viewport value.
 
 Example:
 
 ```yml
 name: noop_test
 pictures:
-  sm: noop
+  sm: dynamic/noop
 ```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "rokka-stacks-generator",
-    "version": "1.0.6",
+    "version": "1.0.7",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "rokka-stacks-generator",
-            "version": "1.0.6",
+            "version": "1.0.7",
             "license": "MIT",
             "dependencies": {
                 "commander": "8.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,13 +57,13 @@ function mapStylePicture(definition: StyleDefinition): StackDefinition[] {
     const pictures = definition.pictures || {};
 
     return Object.keys(pictures).map((viewport) => {
-        if (pictures[viewport] === 'noop') {
+        if (typeof pictures[viewport] === 'string' || pictures[viewport] instanceof String) {
             return {
-                name: 'dynamic/noop',
+                name: pictures[viewport] as string,
             };
         }
 
-        // pictures[viewport] is not 'noop', so we can be sure it's a ViewportSize.
+        // pictures[viewport] has a width and a height in it, so we can safely assume it's a ViewportSize
         const { width, height, mode, crop } = pictures[viewport] as ViewportSize;
         const modeFallback = mode ?? 'fill';
         const cropFallback = crop ?? true;

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import path from 'path';
 import glob from 'glob';
 import yaml from 'yaml';
 import parseArgs from './cli';
-import RokkaHandler, { StyleDefinition, StackDefinition, Style } from './rokka';
+import RokkaHandler, { StyleDefinition, StackDefinition, Style, ViewportSize } from './rokka';
 
 function getFiles(folder: string): Promise<string[]> {
     return new Promise((resolve, reject) => {
@@ -57,7 +57,14 @@ function mapStylePicture(definition: StyleDefinition): StackDefinition[] {
     const pictures = definition.pictures || {};
 
     return Object.keys(pictures).map((viewport) => {
-        const { width, height, mode, crop } = pictures[viewport];
+        if (pictures[viewport] === 'noop') {
+            return {
+                name: 'dynamic/noop',
+            };
+        }
+
+        // pictures[viewport] is not 'noop', so we can be sure it's a ViewportSize.
+        const { width, height, mode, crop } = pictures[viewport] as ViewportSize;
         const modeFallback = mode ?? 'fill';
         const cropFallback = crop ?? true;
 

--- a/src/rokka.ts
+++ b/src/rokka.ts
@@ -28,7 +28,7 @@ export interface StyleDefinition {
     crop?: boolean;
     ratio?: Ratio;
     sizes?: number[];
-    pictures?: Record<string, ViewportSize|'noop'>;
+    pictures?: Record<string, ViewportSize|string>;
     viewport: Viewport;
 }
 
@@ -41,20 +41,16 @@ export interface ResizeStackDefinition {
     crop?: boolean;
 }
 
-export interface NoopStackDefinition {
-    name: 'dynamic/noop'
+export interface ReusedStackDefinition {
+    name: string;
 }
 
-export type StackDefinition = ResizeStackDefinition|NoopStackDefinition
+export type StackDefinition = ResizeStackDefinition|ReusedStackDefinition
 
 export interface Style {
     name: string;
     ratio?: Ratio;
     stacks: StackDefinition[];
-}
-
-function isNoopStack(stack: StackDefinition): stack is NoopStackDefinition {
-    return stack.name === 'dynamic/noop'
 }
 
 export default class RokkaHandler {
@@ -70,7 +66,7 @@ export default class RokkaHandler {
     }
 
     createStack(stack: StackDefinition): Promise<StackDefinition> {
-        if (isNoopStack(stack)) {
+        if (!('width' in stack && 'height' in stack)) {
             return Promise.resolve(stack)
         }
 

--- a/test/output/styles.json
+++ b/test/output/styles.json
@@ -1,4 +1,13 @@
 {
+  "noop_test": {
+    "name": "noop_test",
+    "type": "picture",
+    "stacks": [
+      {
+        "name": "dynamic/noop"
+      }
+    ]
+  },
   "slider_image": {
     "name": "slider_image",
     "type": "picture",

--- a/test/output/styles.json
+++ b/test/output/styles.json
@@ -5,6 +5,9 @@
     "stacks": [
       {
         "name": "dynamic/noop"
+      },
+      {
+        "name": "slider_image"
       }
     ]
   },

--- a/test/stacks_noop.yml
+++ b/test/stacks_noop.yml
@@ -1,3 +1,4 @@
 name: noop_test
 pictures:
-  sm: noop
+  sm: dynamic/noop
+  md: slider_image

--- a/test/stacks_noop.yml
+++ b/test/stacks_noop.yml
@@ -1,0 +1,3 @@
+name: noop_test
+pictures:
+  sm: noop


### PR DESCRIPTION
This allows for `noop` stacks to be generated, in case a viewport needs to have an original image being displayed.

See README.md for example.